### PR TITLE
Add copilot ping script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # copilot-test
+
+## 使用说明
+
+1. 克隆仓库到本地：
+   ```bash
+   git clone https://github.com/nickhou1983/copilot-test.git
+   ```
+
+2. 进入仓库目录：
+   ```bash
+   cd copilot-test
+   ```
+
+3. 运行脚本：
+   ```bash
+   ./copilot-ping.sh
+   ```
+
+4. 脚本会运行24小时，并将结果输出到文件`copilot-ping`中。

--- a/copilot-ping.sh
+++ b/copilot-ping.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# URL to test
+URL="https://api.business.githubcopilot.com"
+
+# Output file
+OUTPUT_FILE="copilot-ping"
+
+# Run ping command for 24 hours and output results to file
+ping -c 86400 $URL > $OUTPUT_FILE


### PR DESCRIPTION
Add a shell script to test the network stability of the Github Copilot Chat API URL using the Ping command for a 24-hour period.

* **copilot-ping.sh**: Create a shell script that pings the URL `https://api.business.githubcopilot.com` for 24 hours and outputs the results to a file named `copilot-ping`.
* **README.md**: Update the README file to include instructions on how to clone the repository, navigate to the directory, and run the script.

